### PR TITLE
Remove retired coders from coder index and category show

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,37 @@
 exit
+category_path(category.slug)
+category_path(category.name)
+category_path(mobile)
+category_path(274)
+category.id
+category
+exit
+coder2
+coder2.update(category: "mobile")
+coder2 = create(:coder)
+coder
+coder.update(category_id: 1)
+coder.update(category: "mobile")
+coder
+coder2.category = coder
+coder2
+category
+coder2 = create(:coder, {:category_id => 3})
+coder2 = create(:coder, {:category => "Front End"})
+coder2 = create(:coder, :category => "Front End")
+category
+category = Category.create(name: "Front End")
+cat
+cat = Category.create(name: "big data")
+cat
+cat = Category.create(name: "mobile")
+cat = _
+Category.create(name: "mobile")
+coder2 = create(:coder, category_id => )
+coder2 = create(:coder, category => "mobile")
+coder2 = create(:coder, :category => "mobile")
+coder
+exit
 next
 params
 next

--- a/app/controllers/coders_controller.rb
+++ b/app/controllers/coders_controller.rb
@@ -1,10 +1,9 @@
 class CodersController < ApplicationController
   def index
-    @coders = Coder.all
+    @coders = Coder.where(active: true)
   end
 
   def show
     @coder = Coder.find(params[:id])
   end
 end
-

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,4 +13,8 @@ class Category < ActiveRecord::Base
   def assign_slug
     self.slug ||= name.parameterize if name
   end
+
+  def active_coders
+    coders.where(active: true)
+  end
 end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,6 +1,6 @@
 <h2><%= @category.name %></h2>
 
-<% @category.coders.each_slice(4) do |coder| %>
+<% @category.active_coders.each_slice(4) do |coder| %>
   <div class="row">
     <% attributes = "attributes" %>
     <%= render partial: "shared/list", locals: { coder: coder, attributes: attributes } %>

--- a/spec/features/user_can_view_retired_coder_but_not_add_spec.rb
+++ b/spec/features/user_can_view_retired_coder_but_not_add_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 feature "When a user views a retired coder" do
   scenario "they cannot add them to their team" do
+    category = Category.create(name: "mobile")
     coder = create(:coder)
+    coder.update(category_id: category.id)
     coder.update_attributes(active: false)
 
     visit coder_path(coder)
@@ -10,5 +12,10 @@ feature "When a user views a retired coder" do
     expect(current_path).to eq(coder_path(coder))
     expect(page).to_not have_button("Add Genius")
     expect(page).to have_content("Coder in NSA Custody or Russian Gulag")
+
+    visit coders_path
+    expect(page).to_not have_content(coder.name)
+    visit category_path(category.slug)
+    expect(page).to_not have_content(coder.name)
   end
 end


### PR DESCRIPTION
@thompickett @thePaulista 
Retired coders no longer show up on the coder index or category show pages. Tests passing. Recommend merging to master.