### PR TITLE
Make historical contracts pull from historical costs

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,25 @@
 exit
+coder.teammates.find_by(contract_id: @contract.id).cost
+coder.teammates.find_by(contract_id: @contract.id)
+coder.teammates
+coder.teammates.find(@contract.id)
+coder.teammates.find(@contract.id).cost
+coder.teammates
+coder.teammate
+teammate
+@contract.id
+@contract
+coder
+teammate.cost
+teammates.cost
+teammate
+coder.teammates
+coder
+next
+coder
+coder.teammates
+coder.teammate
+exit
 coder.id.to_s
 coder.id
 @coder.id

--- a/app/models/coder.rb
+++ b/app/models/coder.rb
@@ -9,10 +9,14 @@ class Coder < ActiveRecord::Base
   has_many :contracts, through: :teammates
 
   def formatted_cost
-    sprintf("%.2f", cost)
+    format("%.2f", cost)
   end
 
   def self.active?
     where(active: true)
+  end
+
+  def contract_cost(contract)
+    format("%.2f", teammates.find_by(contract_id: contract.id).cost)
   end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -12,7 +12,7 @@ class Contract < ActiveRecord::Base
   end
 
   def total_cost
-    cost = coders.reduce(0) do |sum, coder|
+    cost = teammates.reduce(0) do |sum, coder|
       sum = sum + coder.cost.to_f
     end
     sprintf("%.2f", cost)

--- a/app/views/shared/_contract.html.erb
+++ b/app/views/shared/_contract.html.erb
@@ -12,7 +12,7 @@
           <p><%= link_to coder.name, coder_path(coder.id) %></p>
         </td>
         <td class="table-decimal">
-          <p>$<%= coder.formatted_cost %></p>
+          <p>$<%= coder.contract_cost(@contract) %></p>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Historical contracts now show both the actual price paid and the actual price of the coders at the time the contract was created.